### PR TITLE
Install headless Chrome - Stable release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,14 @@ RUN yarn build $project
 
 FROM node:lts-slim
 
+# Install Google Chrome Stable
+RUN apt-get update && apt-get install gnupg wget -y && \
+    wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
+    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
+    apt-get update && \
+    apt-get install google-chrome-stable -y --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
 ARG project
 
 # Create app directory


### PR DESCRIPTION
Integrate Chrome (the latest stable release) into the Docker image 